### PR TITLE
Add PhpMyAdmin install script and serve on port 8888

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,9 +10,13 @@ Vagrant.configure(2) do |config|
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 8000, host: 8000
 
+  # PhpMyAdmin at 8888
+  config.vm.network "forwarded_port", guest: 8888, host: 8888
+
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
   end
 
   config.vm.provision :shell, :privileged => false,  :path => "bin/startup.sh", :run => 'always'
+  config.vm.provision :shell, :privileged => true,   :path => "bin/phpmyadmin.sh"
 end

--- a/bin/phpmyadmin.sh
+++ b/bin/phpmyadmin.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Description: Script file to install PhpMyAdmin inside Vagrant box(jankrib/ubuntu-gae-php)
-#              And configure with apache2 to work on port 8888, username root password vagrant
+#              and configure with apache2 to work on port 8888, username root password vagrant
 # Author: Abdelaziz Elrashed(aeemh.sdn@gmail.com)
-# Date: 10-03-2016 13:00 GMT+3
+# Created Date: 10-03-2016 13:00 GMT+3
 
 # new line variable
 nl='

--- a/bin/phpmyadmin.sh
+++ b/bin/phpmyadmin.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Description: Script file to install PhpMyAdmin inside Vagrant box(jankrib/ubuntu-gae-php)
+#              And configure with apache2 to work on port 8888, username root password vagrant
+# Author: Abdelaziz Elrashed(aeemh.sdn@gmail.com)
+# Date: 10-03-2016 13:00 GMT+3
+
+# new line variable
+nl='
+'
+
+echo "Updating Repositroy..."
+sudo apt-get -y update
+sudo apt-get -y install debconf-utils
+
+echo "Installing php5-gd..."
+sudo apt-get -y install php5-gd
+
+echo "Installing php5-mcrypt..."
+sudo apt-get -y install php5-mcrypt
+
+echo "Installing phpmyadmin..."
+export DEBIAN_FRONTEND=noninteractive
+
+sudo debconf-set-selections <<< 'phpmyadmin phpmyadmin/dbconfig-install boolean true'
+sudo debconf-set-selections <<< 'phpmyadmin phpmyadmin/app-password-confirm password vagrant'
+sudo debconf-set-selections <<< 'phpmyadmin phpmyadmin/mysql/admin-pass password vagrant'
+sudo debconf-set-selections <<< 'phpmyadmin phpmyadmin/mysql/app-pass password vagrant'
+sudo debconf-set-selections <<< 'phpmyadmin phpmyadmin/reconfigure-webserver multiselect apache2'﻿
+
+sudo apt-get -q -y install phpmyadmin
+
+echo "Enable mcrypt Module..."
+sudo php5enmod mcrypt
+
+echo "Configure PhpMyAdmin to work in port(8888)..."
+sudo mv /etc/phpmyadmin/apache.conf /etc/phpmyadmin/apache.conf.old
+sudo echo "<VirtualHost *:8888>${nl}$(cat /etc/phpmyadmin/apache.conf.old)${nl}</VirtualHost>" > /etc/phpmyadmin/apache.conf
+sudo echo "<?php header('location: /phpmyadmin');" > /var/www/index.php
+
+# Make apache Listen to port 8888 for PhpMyAdmin
+sudo echo "Listen 8888" >> /etc/apache2/ports.conf 
+
+echo "Restart apache2..."
+# restart apache2
+sudo service apache2 restart


### PR DESCRIPTION
Hi,
I like your work and I add PhpMyAdmin install script which do all the job and put access at port 8888.
**username** root **password** vagrant
PhpMyAdmin will be always up-to-date, just `vagrant destroy` and `vagrant up`.
I think we can make that automation for GAE platform, php5 & mysql.

Thanks for your start, Salam
